### PR TITLE
💻 add remote-explorer icon

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
-			]
+			],
+			"preLaunchTask": "export"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ extension items
 ### activity bar
 
 - 🌿 source-control
+- 💻 remote-explorer
 
 ### status bar
 

--- a/references/product-icons-fun.md
+++ b/references/product-icons-fun.md
@@ -1,6 +1,7 @@
 ### activity bar
 
 - 🌿 source-control
+- 💻 remote-explorer
 
 ### status bar
 


### PR DESCRIPTION
Changes:
1. use 💻 as icon of remote explorer.
2. set export task as pre-launch task of launch.

BTW, I can't see any icons even the normal version in preview window if I build and run directly, but I just find out that the remote explorer icon disappears along with the others then I think maybe it works.